### PR TITLE
Added functionality to add a class. Removed the numeric indicators from ...

### DIFF
--- a/sh2ju.sh
+++ b/sh2ju.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-### Copyright 2010 Manuel Carrasco Moñino. (manolo at apache.org) 
+### Copyright 2010 Manuel Carrasco Moñino. (manolo at apache.org)
 ###
 ### Licensed under the Apache License, Version 2.0.
 ### You may obtain a copy of it at
@@ -9,11 +9,12 @@
 ### A library for shell scripts which creates reports in jUnit format.
 ### These reports can be used in Jenkins, or any other CI.
 ###
-### Usage: 
+### Usage:
 ###     - Include this file in your shell script
 ###     - Use juLog to call your command any time you want to produce a new report
 ###        Usage:   juLog <options> command arguments
 ###           options:
+###             -class="MyClass" : a class name which will be shown in the junit report
 ###             -name="TestName" : the test name which will be shown in the junit report
 ###             -error="RegExp"  : a regexp which sets the test as failure when the output matches it
 ###             -ierror="RegExp" : same as -error but case insensitive
@@ -29,7 +30,7 @@ juDIR=`pwd`/results
 mkdir -p "$juDIR" || exit
 
 # The name of the suite is calculated based in your script name
-suite=`basename $0 | sed -e 's/.sh$//' | tr "." "_"`
+suite=""
 
 # A wrapper for the eval method witch allows catching seg-faults and use tee
 errfile=/tmp/evErr.$$.log
@@ -44,25 +45,39 @@ juLogClean() {
   rm -f "$juDIR"/TEST-*
 }
 
-# Execute a command and record its results 
+# Execute a command and record its results
 juLog() {
-  
+  suite="";
+  errfile=/tmp/evErr.$$.log
+  date=`which gdate || which date`
+  asserts=00; errors=0; total=0; content=""
+
   # parse arguments
   ya=""; icase=""
-  while [ -z "$ya" ]; do  
+  while [ -z "$ya" ]; do
     case "$1" in
-  	  -name=*)   name=$asserts-`echo "$1" | sed -e 's/-name=//'`;   shift;;
+  	  -name=*)   name=`echo "$1" | sed -e 's/-name=//'`;   shift;;
+  	  -class=*)  class=`echo "$1" | sed -e 's/-class=//'`;   shift;;
       -ierror=*) ereg=`echo "$1" | sed -e 's/-ierror=//'`; icase="-i"; shift;;
       -error=*)  ereg=`echo "$1" | sed -e 's/-error=//'`;  shift;;
       *)         ya=1;;
     esac
-  done  
+  done
 
-  # use first arg as name if it was not given 
+  # use first arg as name if it was not given
   if [ -z "$name" ]; then
-    name="$asserts-$1" 
+    name="$asserts-$1"
     shift
   fi
+
+  if [[ "$class" = "" ]]; then
+    class="default"
+  fi
+
+  echo "name is: $name"
+  echo "class is: $class"
+
+  suite=$class
 
   # calculate command to eval
   [ -z "$1" ] && return
@@ -77,7 +92,7 @@ juLog() {
   outf=/var/tmp/ju$$.txt
   >$outf
   echo ""                         | tee -a $outf
-  echo "+++ Running case: $name " | tee -a $outf
+  echo "+++ Running case: $class.$name " | tee -a $outf
   echo "+++ working dir: "`pwd`           | tee -a $outf
   echo "+++ command: $cmd"            | tee -a $outf
   ini=`$date +%s.%N`
@@ -86,8 +101,8 @@ juLog() {
   rm -f $errfile
   end=`date +%s.%N`
   echo "+++ exit code: $evErr"        | tee -a $outf
-  
-  # set the appropriate error, based in the exit code and the regex  
+
+  # set the appropriate error, based in the exit code and the regex
   [ $evErr != 0 ] && err=1 || err=0
   out=`cat $outf | sed -e 's/^\([^+]\)/| \1/g'`
   if [ $err = 0 -a -n "$ereg" ]; then
@@ -99,7 +114,6 @@ juLog() {
 
   # calculate vars
   asserts=`expr $asserts + 1`
-  asserts=`printf "%.2d" $asserts`
   errors=`expr $errors + $err`
   time=`echo "$end - $ini" | bc -l`
   total=`echo "$total + $time" | bc -l`
@@ -121,11 +135,24 @@ $out
     </testcase>
   "
   ## testsuite block
-  cat <<EOF > "$juDIR/TEST-$suite.xml"
-  <testsuite failures="0" assertions="$assertions" name="$suite" tests="1" errors="$errors" time="$total">
-    $content
-  </testsuite>
+
+  if [[ -e "$juDIR/TEST-$suite.xml" ]]; then
+
+    # file exists. Need to append to it. If we remove the testsuite end tag, we can just add it in after.
+    sed -i "s^</testsuite>^^g" $juDIR/TEST-$suite.xml ## remove testSuite so we can add it later
+    cat <<EOF >> "$juDIR/TEST-$suite.xml"
+     $content
+    </testsuite>
 EOF
+
+  else
+    # no file exists. Adding a new file
+    cat <<EOF > "$juDIR/TEST-$suite.xml"
+    <testsuite failures="0" assertions="$assertions" name="$suite" tests="1" errors="$errors" time="$total">
+    $content
+    </testsuite>
+EOF
+  fi
 
 }
 

--- a/sh2ju_example.sh
+++ b/sh2ju_example.sh
@@ -29,3 +29,7 @@ myCmd() {
 
 juLog  -name=myCustomizedMethod             myCmd '*.sh'
 
+#### Success command with a class defined
+juLog  -name=myTrueCommand -class=TestFunctionality                 true
+
+


### PR DESCRIPTION
What has been tested: I have done some testing with multiple test classes. I have also tested the default behavior when class is not specified. That hasn't been tested as extensively (e.g. I only tried one test case w/o specifying a class).

What has not been tested: Previous versions where class is not specified (more than a couple tests.

Other concerns: There might be some confusion between suite/class. The argument is passed in as class but we pass it onto suite. That's just a code-style-maintainability concern.

I also removed the numbering from the name of the test case. That was a personal preference in terms of how I'd like things displayed. If you feel strongly about it, then we can rework the patch to add that back in.

A few more examples might be useful, but I think that is enough for folks to understand how to use the class argument.
