### PR TITLE
Squashed error message if gdate is not found (issue #4)

### DIFF
--- a/sh2ju.sh
+++ b/sh2ju.sh
@@ -22,7 +22,7 @@
 ###
 
 asserts=00; errors=0; total=0; content=""
-date=`which gdate || which date`
+date=`which gdate || which date` 2>/dev/null
 
 # create output folder
 juDIR=`pwd`/results


### PR DESCRIPTION
This doesn't handle other errors but to do so seems overkill - for instance a system without "date" isn't going to work very well anyway!
