### PR TITLE
Do not print a warning when gdate is not present

### DIFF
--- a/sh2ju.sh
+++ b/sh2ju.sh
@@ -22,7 +22,7 @@
 ###
 
 asserts=00; errors=0; total=0; content=""
-date=`which gdate || which date`
+date=`which gdate 2>/dev/null || which date`
 
 # create output folder
 juDIR=`pwd`/results


### PR DESCRIPTION
When `gdate` is not present on a system, we safely get back to date, so it
should not print an error.

We however still print a warning if `date` or `which` is not found.