### PR TITLE
Fix stderr redirection of second "which" command

### DIFF
--- a/sh2ju.sh
+++ b/sh2ju.sh
@@ -50,7 +50,7 @@ juLogClean() {
 juLog() {
   suite="";
   errfile=/tmp/evErr.$$.log
-  date=`which gdate || which date`
+  date=`which gdate 2>/dev/null || which date`
   asserts=00; errors=0; total=0; content=""
 
   # parse arguments


### PR DESCRIPTION
Fix stderr redirection of second "which" command used inside the juLog function